### PR TITLE
05.15~05.18

### DIFF
--- a/Byeol-Kim/2023.05.15~05.18/광물캐기.md
+++ b/Byeol-Kim/2023.05.15~05.18/광물캐기.md
@@ -1,0 +1,260 @@
+## 접근
+><a href="https://school.programmers.co.kr/learn/courses/30/lessons/172927"> 광물캐기</a>
+
+저는 처음에 저의 풀이가 맞다고 생각했습니다.
+로직은 다음과 같습니다.
+
+1. 광물의 순서도를 5개의 크기로 자르기
+2. 그 순서도에 맞게 남아 있는 곡괭이로 진행했을 때
+가장 작은 피로도를 가진 곡괭이 제거하고 피로도에 더하기
+3. 위 과정은 모든 곡괭이를 썼거나 순서도에 존재하는 광물을 모두 제거할 때까지 반복한다.
+4. 5개의 크기로 자르고 남은 순서도의 경우 곡괭이가 남아있는 경우 다시 최소의 피로도를 구한다.
+
+
+하지만 위 방법은 틀렸습니다.
+왜냐하면 곡괭이를 선택하는 기준은 현재 남아있는 광물의 순서도에 따라 가장 작은 피로도를 구하는 것이 아니라 미래를 생각해서 선택해야 합니다.
+
+picks = [1, 0, 1]
+minerals = ["stone", "stone", "stone", "stone", "stone", "iron", "iron", "iron", "iron", "iron", "diamond", "diamond"]
+
+의 경우 앞에 5개의 순서도를 자른다고 가정합시다.
+그러면  ["stone", "stone", "stone", "stone", "stone"]이다
+이 광물에 따라 남아 있는 곡괭이의 피로도는 각각 5입니다.
+그럼 둘 중에 누굴 선택해야 할까요?
+
+제 풀이의 경우는 다이아몬드 곡괭이를 선택합니다.
+그럴 경우 최종 피로도를 30이 됩니다.
+
+하지만 만약에 다이아몬드 곡괭이가 아닌 돌 곡괭이를 선택했다면
+최종 피로도는 10 입니다.
+
+즉 제 풀이는 미래를 생각하지 않고 계산하기 때문에 틀렸습니다.
+
+
+따라서 저는 DFS를 이용하여 다시 풀었습니다.
+로직은 아래와 같습니다.
+
+1. DFS를 이용해서 곡괭이를 고르는 모든 경우의 수를 만든다.
+하지만 이전 DFS와 다르게** boolean을 통한 상태 배열의 백트랙킹이 아니라 곡괭이 수를 다시 되돌려 놓는 백트랙킹**입니다. 사실 이 부분을 구현하는게 가장 재미있었습니다.
+ ```java
+ static void dfs(int[] picks, int level, String gok){
+        if(level==cnt){
+            list.add(gok);
+        }else{
+            for(int i=0;i<3;i++){
+                if(picks[i]>0){
+                    picks[i]--;
+                    dfs(picks,level+1,gok+i);
+                    picks[i]++;
+                }
+            }
+               
+        }
+    }
+ ```
+ 
+ 2. 모든 경우의 수를 가지고 가장 작은 피로도를 구합니다.
+ 
+ 
+따라서 저는 틀린 풀이와 DFS로 성공한 풀이 두 가지를 정리했습니다.
+
+
+
+
+
+
+
+
+
+
+
+
+## 틀린 풀이
+```java
+import java.util.*;
+
+class Solution {
+    // 다이아몬드, 철, 돌 순으로
+    static int[] dia = {1,5,25};
+    static int[] iron = {1,1,5};
+    static int[] stone = {1,1,1};
+    static int[] Picks;
+    static int answer=0;
+    
+    
+    
+    public int solution(int[] picks, String[] minerals) {
+        
+        // 각 곡괭이는 종류에 상관엇이 광물 5개를 캔 후에는 사용할 수 없다
+        // 최소의 피로도
+        // 사용할 수 있는 곡괭이 중 아무거나 하나-> 광물 캐기
+        // 한번 사용시작하면 사용할 수 없을 때까지
+        // 광물은 주어진 순서대로만
+        // 광산에 잇는 모든 광물 혹은 더 사용할 광물이 없을 때까지
+        
+        // 가지고 있는 곡괭이의 개수 picks [dia, iron, stone]//최소 1개 이상
+        // 광물들의 순서 minerals // 문자열
+        
+        
+        
+        // 앞의 5개를 최소로 캘수 있는 곡괭이 구하기
+        // 피로도 계산해서 가장 작은 피로도 곡괭이 pick 그 곡괭이가 없을 다음 곡괭이 pick
+        
+        
+        Picks = picks;
+        
+        int next=0;
+        
+        for(int i=0;i+5<=minerals.length;){
+            next = i+5;
+            // 배열 자르기
+            String[] arr = Arrays.copyOfRange(minerals, i, next);
+            if(allZeroPick(Picks)) break; 
+            pickGok(arr);   
+            i=i+5;
+        }
+        
+        
+        // 마지막에 5개에서 남은 아이들
+        if(minerals.length % 5 != 0){
+            if(!allZeroPick(Picks)){
+             String[] arr = Arrays.copyOfRange(minerals,next,minerals.length);
+             pickGok(arr); 
+            }  
+        }
+        
+        
+            
+            
+        return answer;
+    }
+    
+    static void pickGok (String[] arr){
+        
+        //0번째는 다이어모든, 1번째는 철, 3번째가 돌 곡괭이에 해당
+        int[] gok = new int[3]; 
+        
+        // 남아있는 곡괭이들로 arr에 있는 광물을 캣을 때의 피로도 구하기
+        for(int i=0;i<3;i++){
+            if(Picks[i]>0){ // 남아있는 곡괭이가 있으면
+                for(int j=0;j<arr.length;j++){
+                    if(arr[j].equals("diamond")){
+                        gok[i]+=dia[i];
+                    }else if(arr[j].equals("iron")){
+                        gok[i]+=iron[i];
+                    }else{
+                         gok[i]+=stone[i];
+                    }  
+                }  
+            }    
+        }
+        
+        // 각 곡괭이의 피로도를 통해서 가장 작은 피로도를 가지는 곡괭이 고르고
+        // 곡괭이 재고 -1
+        int min = Integer.MAX_VALUE;
+        int index =0;
+        for(int i=0;i<3;i++){
+            if(gok[i]!=0 && gok[i]<min){
+                min=gok[i];
+                index=i;
+            }
+        }
+        
+        answer+=min;
+        System.out.println(answer);
+        Picks[index]-=1;
+        
+    }
+    
+    static boolean allZeroPick(int[] picks){
+        for(int i=0;i<3;i++){
+            if(picks[i]>0)
+                return false;
+        }
+        return true;
+        
+    }
+}
+```
+
+## DFS를 이용한 풀이 (성공)
+```java
+import java.util.*;
+
+class Solution {
+    // 다이아몬드, 철, 돌 순으로
+    static int[] dia = {1,5,25};
+    static int[] iron = {1,1,5};
+    static int[] stone = {1,1,1};
+    
+    static int[] Picks;
+    static int cnt;
+    
+    
+    static ArrayList<String> list = new ArrayList<>();
+    public int solution(int[] picks, String[] minerals) {
+        
+        int answer=0;
+        
+        //곡괭이 종류를 모든 경우의 수로 만들기
+        // 그 경우의 수에서 가장 작은 피로도를 갖는 경우를 return하기
+        
+        
+        cnt = 0;
+        for(int p : picks){
+            cnt+=p;
+        }
+        
+        
+        // 모든 경우의 수 만들기
+        dfs(picks,0,"");
+        
+        int min = Integer.MAX_VALUE;
+        
+        for(String l: list){
+            int piro=0;
+            int index=0;
+            // 이번 경우의 수의 길이
+            for(int i=0;i<l.length();i++){
+              // 광물 캐기
+              for(;index<minerals.length;){
+                  if(minerals[index].equals("diamond")){
+                      piro+=dia[l.charAt(i)-'0'];
+                  }else if(minerals[index].equals("iron")){
+                      piro+=iron[l.charAt(i)-'0'];
+                  }else{
+                       piro+=stone[l.charAt(i)-'0'];
+                  }
+                  index++;
+                  if(index%5==0) break;  
+              }
+                
+     
+            }
+            //System.out.println(piro);
+            if(piro<min) min=piro;
+            
+            
+        }
+        
+        return min;
+        
+    
+    }
+    
+    static void dfs(int[] picks, int level, String gok){
+        if(level==cnt){
+            list.add(gok);
+        }else{
+            for(int i=0;i<3;i++){
+                if(picks[i]>0){
+                    picks[i]--;
+                    dfs(picks,level+1,gok+i);
+                    picks[i]++;
+                }
+            }
+               
+        }
+    }
+}
+```

--- a/Byeol-Kim/2023.05.15~05.18/미로 탈출.md
+++ b/Byeol-Kim/2023.05.15~05.18/미로 탈출.md
@@ -1,0 +1,183 @@
+## 접근
+><a href="https://school.programmers.co.kr/learn/courses/30/lessons/159993">미로 탈출</a>
+
+이 문제를 맞았지만 접근하는 방법이 재미있어 정리해보려고 합니다.
+
+제가 풀었던 문제들은 보통 BFS 문제는 한번의 BFS를 사용하지만
+이 문제는 두개의 DFS를 사용합니다.
+
+
+왜냐하면 문제에도 주어졌지만
+1. 레버를 찾고
+2. 그 다음 출입구를 찾아야하기 때문입니다.
+
+
+따라서 레버를 찾는 최소의 시간 + 레버를 찾은 후 출입구를 찾는 최소의 시간
+이 정답이 됩니다.
+
+따라서 두 개의 BFS를 호출해야 하며
+호출 시 각자 다른 상태배열을 가지게 됩니다.
+
+왜냐하면 레버를 가지고 나서 출입구를 찾는 과정에서 레버를 찾으며 지나간 길을 다시 지날 수 있기 때문입니다.
+
+처음에 저는 아무런 생각없이 BFS를 하나만 사용했다가
+문제를 다시 한번 정독하고 2개의 BFS를 호출해야한다는 것을 깨달았습니다.
+
+따라서 풀이는 아래와 같습니다.
+
+## 풀이
+```java
+import java.util.*;
+
+class Solution {
+    static int[] cx={0,0,-1,1};
+    static int[] cy={1,-1,0,0};
+    
+    static char[][] Maps;
+    
+    static ArrayList<Integer> list;
+    
+    static class XY{
+        int x;
+        int y;
+        int time;
+        public XY(int x, int y, int time){
+            this.x=x;
+            this.y=y;
+            this.time = time;
+        }
+        
+        
+    }
+    
+    
+    public int solution(String[] maps) {
+        int answer = 0;
+        // 통로 레버와 문 -> 레버를 당기고 문으로 -> 이동할 때 1초
+        // 벽
+        // 최소 시간
+        
+        // 미로 100*100
+        // 5개의 문자 S: 시작지점, E: 출구, L: 레버, O: 통로 , X : 벽
+        
+        
+        //탈출할 수 없다면 -1
+        
+        int row = maps.length;
+        int col = maps[0].length();
+        
+        System.out.println(row);
+        System.out.println(col);
+        
+        list = new ArrayList<Integer>();
+        
+        Maps = new char[row][col];
+        
+        XY start = new XY(0,0,0);
+        XY lebber = new XY(0,0,0);
+        
+        
+        for(int i=0;i<row;i++){
+            for(int j=0;j<col;j++){
+               char target = maps[i].charAt(j);
+              Maps[i][j] = target;
+               if(target=='S')
+                  start = new XY(i,j,0);
+               if(target=='L')
+                  lebber = new XY(i,j,0);  
+            }
+        }
+        
+        
+      // 출발 위치에서 레버를 찾는 최적의 시간
+      int timeL =  searchL(start,row,col);
+      // 레버 위치에서 출구를 찾는 최적의 시간
+      int timeE = searchE(lebber,row,col); 
+        
+      
+      if(timeL==Integer.MAX_VALUE || timeE==Integer.MAX_VALUE)
+          return -1;
+      else return timeL+timeE;
+        
+    
+        
+       
+    }
+    // 출발지에서 레버를 찾는 BFS
+    static int searchL(XY start, int row, int col){
+        
+        int min = Integer.MAX_VALUE;
+        boolean[][] visited = new boolean[row][col];
+        Queue<XY> q = new LinkedList<>();
+        q.offer(start);
+        
+        while(!q.isEmpty()){
+            XY cost = q.poll();
+            
+            for(int i=0;i<4;i++){
+                int newX = cost.x + cx[i];
+                int newY = cost.y + cy[i];
+                if(newX <0 || newX >=row || newY<0 || newY>=col) continue;
+                
+                
+                if(!visited[newX][newY]){
+                    if(Maps[newX][newY]=='O'|| Maps[newX][newY]=='E'){
+                        visited[newX][newY]=true;
+                        q.offer(new XY(newX,newY,cost.time+1));
+                        
+                    // 레버인 경우 더이상 BFS를 나아가지 않는다.    
+                    }else if(Maps[newX][newY]=='L'){
+                        visited[newX][newY]=true;
+                        if(min>cost.time+1){
+                            min=cost.time+1;
+                        }
+                    }
+                
+                  }
+            }
+             
+        }
+        
+        return min;
+         
+    }
+    
+     static int searchE(XY start, int row, int col){
+        
+        int min = Integer.MAX_VALUE;
+        boolean[][] visited = new boolean[row][col];
+        Queue<XY> q = new LinkedList<>();
+        q.offer(start);
+        
+        while(!q.isEmpty()){
+            XY cost = q.poll();
+            
+            for(int i=0;i<4;i++){
+                int newX = cost.x + cx[i];
+                int newY = cost.y + cy[i];
+                if(newX <0 || newX >=row || newY<0 || newY>=col) continue;
+                
+                
+                if(!visited[newX][newY]){
+                    if(Maps[newX][newY]=='O'|| Maps[newX][newY]=='L'||Maps[newX][newY]=='S'){
+                        visited[newX][newY]=true;
+                        q.offer(new XY(newX,newY,cost.time+1));
+                        
+                     //출구인 경우 더이상 BFS를 나아가지 않는다.   
+                    }else if(Maps[newX][newY]=='E'){
+                        visited[newX][newY]=true;
+                        if(min>cost.time+1){
+                            min=cost.time+1;
+                        }
+                    }
+                
+                  }
+            }
+             
+        }
+        
+        return min;
+         
+    }
+}
+```

--- a/Byeol-Kim/2023.05.15~05.18/시소 짝궁.md
+++ b/Byeol-Kim/2023.05.15~05.18/시소 짝궁.md
@@ -1,0 +1,197 @@
+
+## 접근
+> <a href="https://school.programmers.co.kr/learn/courses/30/lessons/152996#qna"> 시소짝궁</a>
+
+이 문제는 메모리 초과가 발생하였습니다.
+제한사항을 제대로 보도록 노력해야 겠습니다.
+```
+2 ≤ weights의 길이 ≤ 100,000
+100 ≤ weights[i] ≤ 1,000
+몸무게 단위는 N(뉴턴)으로 주어집니다.
+몸무게는 모두 정수입니다.
+```
+
+입니다. 
+제 풀이의 경우 100,000 * 99,999 번의 연산이 발생합니다.
+시간 초과와 더불어 메모리 초과가 발생할 수 있습니다.
+
+좀 복잡하게 풀었습니다.
+나와 짝궁이 될 수 있는 상대의 몸무게와 나의 몸무게의
+최소공배수를 구합니다.
+
+그 최소공배수로 각자의 몸무게를 나눈 후
+그 몫의 값에 2,3,4를 곱합 결과값을 다시 Set에 넣고
+Set의 크기가 6보다 작으면 중복된 몸무게가 존재하여 상쇄된다고 생각하여 접근하였습니다.
+
+하지만 너무 많은 연산이 발생합니다.
+
+그래서 다른 분의 풀이를 참고하였습니다.
+
+일단 풀이는 Map을 이용한 방법과
+Map이 아니라 두 가지 조건을 이용한 풀이가 있습니다.
+
+
+- Map을 이용한 풀이의 로직
+  - 이 풀이는 Map에 저장된 키를 통해 자신과 상쇄된 사람의 수를 value로 저장하는 것이다.
+  - 이 풀이는 메모제이션의 방법이라고 생각하면 된다.
+
+- Map을 이용하지 않은 풀이의 로직
+  - 1. 오름차순으로 정렬한다.
+  - 2. 이전 값과 같은 경우 이전에 상쇄된 사람의 수에 중복된 1회의 값을 제거하여 answer에 누적한다.
+  - 3. 이전 값과 같지 않은 경우 2,3,4를 본인과 본인 이후의 값들에 곱해 같은 경우 상쇄되는 사람의 수에 +1을 한다.
+
+
+## 메모리 초과인 나의 풀이
+
+```java
+import java.util.*;
+
+class Solution {
+    
+    static ArrayList<Value> list = new ArrayList<>();
+    static List<Integer> mm = List.of(2,3,4);
+    static class Value {
+        int a;
+        int b;
+        public Value(int a, int b){
+            this.a = a;
+            this.b = b;
+        }
+    }
+    
+    public long solution(int[] weights) {
+        long answer = 0;
+        
+        
+        
+        //1. 모든 조합의 수 만들기
+        //2. 두수가 같은가?
+        //3. 같지 않은가? -> 최대 공약수가 존재하는가? -? 두수의 비율이 2보다 작은가?
+        
+        // 1번 과정
+       for(int i=0;i<weights.length-1;i++){
+           for(int j=i+1;j<weights.length;j++){
+               list.add(new Value(weights[i],weights[j]));
+           }
+       }
+        
+        
+        for(Value l : list){
+            System.out.println("a:"+l.a+",b:"+l.b);
+        }
+        
+      // 2. 만들어진 배열을 검사기
+      answer = checkSee(list);
+        
+        
+        
+        return answer;
+    }
+    
+    static int checkSee(ArrayList<Value> list){
+        int cnt=0;
+        for(int i=0;i<list.size();i++){
+            if(list.get(i).a == list.get(i).b){
+                cnt++;
+                System.out.println("같은 경우 a:"+list.get(i).a+",b:"+list.get(i).b);
+            }else{
+                //1. 최대 공약수 구하기
+                int abGcd = gcd(list.get(i).a,list.get(i).b);
+               //2. 최소공배수 구하기
+                int abLcm = list.get(i).a*list.get(i).b/abGcd;
+                //3. 만들 수 있는가 체크하기
+                int A = abLcm / list.get(i).a ;
+                int B = abLcm/list.get(i).b;
+                Set<Integer> set = new HashSet<>();
+                for(int m : mm){
+                    set.add(A*m);
+                    set.add(B*m);
+                }
+                if(set.size()<6){
+                  cnt++;
+                }
+            }
+             
+        }
+        return cnt; 
+        
+    }
+    static int gcd(int A, int B){
+        if(B==0) return A;
+        return gcd(B,A%B);
+    }
+    
+  
+}
+```
+
+## Map을 이용한 풀이- 메모제이션
+```java
+class Solution {
+    public long solution(int[] weights) {
+    	long answer = 0;
+        Arrays.sort(weights);
+        Map<Double, Integer> map = new HashMap<>();
+        for(int i : weights) {
+    		double a = i*1.0;
+    		double b = (i*2.0)/3.0;
+    		double c = (i*1.0)/2.0;
+    		double d = (i*3.0)/4.0;
+    		if(map.containsKey(a)) answer += map.get(a);
+    		if(map.containsKey(b)) answer += map.get(b);
+    		if(map.containsKey(c)) answer += map.get(c);
+    		if(map.containsKey(d)) answer += map.get(d);
+    		map.put((i*1.0), map.getOrDefault((i*1.0), 0)+1);
+        }
+        
+        return answer;
+    }
+}
+```
+
+
+## Map을 이용하지 않은 풀이 
+```java
+import java.util.*;
+
+class Solution {
+   
+    public long solution(int[] w) {
+       
+        long answer=0;
+        Arrays.sort(w);
+        
+        int len = w.length;
+        int zeroP =0;
+        for(int i=0;i<len-1;i++){
+            // 이전값과 같은 경우 
+            if(i>0 && w[i]==w[i-1]){
+                // 이전 상쇄된 사람의 수에서 중복된 1회의 연산(100-100)을 마이너스
+                zeroP--;
+                answer+=zeroP;
+                continue;
+            }
+            zeroP=0;
+            for(int j=i+1;j<len;j++){
+                if(w[i]==w[j]
+                  || w[i]==w[j]*2
+                  || w[i]*2 == w[j]
+                  || w[i]*3 == w[j]*2
+                  || w[i]*2 == w[j]*3
+                  || w[i]*3 == w[j]*4
+                  || w[i]*4 == w[j]*3
+                  ){
+                    zeroP++; 
+                }
+                  
+            }//for j
+            
+            answer+=zeroP;    
+        }// for i
+        
+        
+        return answer;
+    }
+  
+}
+```

--- a/Byeol-Kim/2023.05.15~05.18/혼자 놀기의 달인.md
+++ b/Byeol-Kim/2023.05.15~05.18/혼자 놀기의 달인.md
@@ -1,0 +1,151 @@
+## 접근
+> <a href="https://school.programmers.co.kr/learn/courses/30/lessons/131130"> 혼자 놀기의 달인</a>
+
+이 문제는 맞았지만
+다른 스터디의 풀이법을 참고해보는 것이 좋을 거 같아 정리해보려고 합니다.
+
+저는 DBS를 사용해서 풀지 않았습니다.
+전체적인 접근법은 다음과 같습니다.
+1. 아무 상자나 연다. 
+2. 혼자 놀기를 진행하면서 열 수 있는 상자까지 열고 점수를 누적한다.
+3. 그 값을 list에 저장한다.
+
+위 과정을 반복하면 list에 혼자 놀면서 생긴 점수들이 저장되어있고
+이 list를 정렬시켜 맨 앞에 2개의 값을 더하면
+문제에서 구하라는 2회까지의 최대값이 반환된다.
+
+단 맨 앞 값이 카드를 더한 값과 같다면 0을 반환한다.
+
+하지만 위 풀이와 별개로 DFS로 접근한 팀원이 있어
+이 방법으로 다시 풀어보았다.
+
+
+## 나의 풀이(구현)
+```java
+import java.util.*;
+
+class Solution {
+    public int solution(int[] cards) {
+        int answer = 0;
+        //카드 총 100장, 각 카드에는 1부터 100까지 숫자가 하나씩
+        // 2이상 100이하 자연수 하나를 정해 그 수보다 작거나 같은 숫자 카드 준비
+        // 준비한 카드의 수만큼 작은 상자를 준비하면 게임을 시작
+        
+        // 준비된 상자에 카드 한장씩 넣고 상자를 무작위로 섞어 일렬로 나열
+        // 그 일렬에 1번부터 번호 붙이기
+        // 상자에서 꺼낸 번호에 해당하는 상자 열기
+        // 열어야 하는 상자가 열려 있을 때까지 이게 1회
+        
+        // 1회만으로 모두 열었으면 0점
+        
+        // 1번 상자 그룹에 속한 상자의 수 * 2번 상자 그룹에 속한 값
+        
+        
+        // 횟수 넣기
+        ArrayList<Integer> turn = new ArrayList<>();
+        
+        //상자의 번호가 저장된다.
+        ArrayList<Integer> box= new ArrayList<>();
+        
+        // 처음 상자의 시작은 그냥 1번부터
+        int index=0;
+        
+        // 언제 결국 그만두는가에 대한 횟수
+        int cnt=0;
+        
+        
+        // 모든 상자가 들어오기 전까지
+        while(box.size()<cards.length){
+            
+        
+            //1. 없다면 넣기
+            if(!box.contains(index+1)){
+                box.add(index+1);
+                index=cards[index]-1;
+                cnt++;
+                // 마지막 박스의 경우에는 turn값에 넣어버리기
+                if(box.size()==cards.length) turn.add(cnt); 
+            //2. 이미 있으면
+            }else{
+                turn.add(cnt);
+                cnt=0;
+                // box에 담아있지 않은 다음 박스 번호를 찾기
+                index=findNext(cards,box);
+            } 
+        }
+        
+        // 내림차순 정렬
+         turn.sort(Comparator.reverseOrder());
+        
+
+        
+        // 1회에서 마무리되는 경우에는 return 0
+        if(turn.get(0)==cards.length) return 0;
+        // 구하고자 하는 것은 2회차까지의 값이므로
+        return turn.get(0) * turn.get(1);
+        
+        
+         
+     
+    }
+    // 선택되지 않은 다음 박스
+    static int findNext(int[] cards, ArrayList<Integer> box){
+        
+        int length = cards.length;
+        
+        for(int i=1;i<=length;i++){
+            if(!box.contains(i))
+                return i-1;
+        }
+        
+        return 0;
+        
+    }
+}
+```
+
+## DFS를 이용한 풀이
+```java
+import java.util.*;
+
+class Solution {
+    
+    static ArrayList<Integer> list = new ArrayList<>();
+    static boolean[] visited;
+    public int solution(int[] cards) {
+      
+        int length = cards.length;
+        visited = new boolean[length];
+        
+        for(int i=0;i<length;i++){
+            if(!visited[i]){
+                visited[i]=true;
+                dfs(1,i,cards);
+            }
+        }
+        
+        Collections.sort(list,Collections.reverseOrder());
+        
+        if(list.size()<2)
+            return 0;
+        else 
+           return list.get(0)*list.get(1);
+        
+        
+        
+     
+    }
+    static void dfs(int level, int boxNum, int[] cards){
+        int nextBoxNum = cards[boxNum]-1;
+        if(!visited[nextBoxNum]){
+            visited[nextBoxNum]=true;
+            dfs(level+1,nextBoxNum,cards);
+        }else{
+            list.add(level);
+        } 
+        
+    }
+
+   
+}
+```

--- a/Byeol-Kim/2023.05.15~05.18/후보키 문제.md
+++ b/Byeol-Kim/2023.05.15~05.18/후보키 문제.md
@@ -1,0 +1,238 @@
+## 접근
+> <a href="https://school.programmers.co.kr/learn/courses/30/lessons/42890#">후보기 문제</a>
+
+이 문제는 키를 모든 경우의 수로 만듭니다.
+단, AB와 BA는 같은 키이기 때문에 백트랙킹과 시작하는 지점을 기억해야합니다.
+
+따라서 저는 다음과 같은 방법으로 접근했습니다.
+
+1. DFS로 모든 경우의 키를 만든다. 단, 예를 들어 AB와 BA는 같기 때문에 앞에 언급된 키는 다시 불러오지 않는다.
+```java
+ static void dfs(int cnt, int start, int level, String answer) {
+        if(level==cnt){
+            return;
+        }else{
+            for(int i=start;i<cnt;i++){
+                  if(!visited[i]){
+                      visited[i]=true;
+                      dfs(cnt,i,level+1,answer+i);
+                      result.add(answer+i);
+                      visited[i]=false;   
+                  }     
+                   
+              }
+        }  
+    }
+```
+2. 최소성을 만족시키기 위해서 키를 길이 순으로 정렬한다.
+```java
+   Comparator<String> comp = new Comparator<>(){
+            
+            public int compare(String s1, String s2){
+                return s1.length() -s2.length();
+            }  
+        };
+```
+3. 이제 유일성을 만족시키기 위해서 각 키에 대해서 tuple이 중복되지 않는지 검사한다.
+이 때 Set을 만들어서 Set의 size와 튜플의 개수가 같다면 유일성을 만족한다.
+```java
+// 3. 유일성을 위해 set 
+for(int j=0;j<relation.length;j++){
+                StringBuilder sb = new StringBuilder();
+                for(char c : charArr){
+                    sb.append(relation[j][c-'0']).append(" ");
+                }
+                set.add(sb.toString());
+            }
+           
+            if(set.size()==tuple && !check(r,key)){
+                
+                   key.add(r);
+                   System.out.println("후보키:"+r);                
+                
+            }
+        }
+```
+4. 최소성을 만족시키기 위해서 "A"를 제외한 "A"가 들어가 모든 키를 제거한다.
+
+ 이 4번 과정에서 저는 시간을 많이 낭비했습니다.
+ 아래와 같이 java 8에 도입된 removeIf를 사용했는데
+ ```
+ if(set.size()<tuple){
+               result.removeIf(item-> item.contains(r));
+             }
+ ```
+ ConcurrentModificationException이 발생했습니다.
+ ```
+Exception in thread "main" java.util.ConcurrentModificationException
+	at java.base/java.util.ArrayList$Itr.checkForComodification(ArrayList.java:1013)
+	at java.base/java.util.ArrayList$Itr.next(ArrayList.java:967)
+	at Solution.solution(Unknown Source)
+	at SolutionTest.lambda$main$0(Unknown Source)
+	at SolutionTest$SolutionRunner.run(Unknown Source)
+	at SolutionTest.main(Unknown Source)
+ ```
+ 이 예외는 
+ >Note that this exception does not always indicate that an object has been concurrently modified by a different thread. If a single thread issues a sequence of method invocations that violates the contract of an object, the object may throw this exception. For example, if a thread modifies a collection directly while it is iterating over the collection with a fail-fast iterator, the iterator will thow this exception
+
+ 위와 같이 설명되어 있습니다.
+아무래도 i번째를 삭제할 때 i+1번째가 i번째로 당겨오게 되면서 그에 다른 검사가 누락되어 발생되는 것으로 보입니다.
+
+ 사실 removeIf는 자바 8에 도입되었는데 Iterator의 불편함을 개선시키기 위해서 도입되었다고 했습니다. 즉 아래의 예시처럼 복잡한 코드를 한줄로 끝낼 수 있습니다.
+ ```java
+Iterator<String> iter = li.iterator();
+while(iter.hasNext()){
+    if(iter.next().equalsIgnoreCase("str3"))
+        iter.remove();
+ }
+ ```
+ 제가 저와 같은 상황으로 stack overflow에 올려진 글을 보았는데
+ 이상하게도 removeIf나 Iterator를 이용하라고 했습니다.
+ 하지만 여전히 ConcurrentModificationException이 발생되었습니다.
+ (원인을 알고 계시다면 댓글 부탁드립니다.)
+
+ 그래서 직접 그냥 구현하기로 했습니다.
+ 
+ 4번 과정은 그래서 아래와 같이
+ 현재 후보키로 들어갈 미래의 키가 현재 후보키로 등록된 키의 일부를 가지고 있는지
+ 검사하는 메서드입니다.
+ ```java
+ static boolean check(String r ,ArrayList<String> key){
+        int cnt =0;
+        // 후보키로 등록된 키 k
+        for(String k : key){
+            cnt =0;
+            String[] kArr = k.split("");
+            for(String kIndex : kArr){
+                //미래의 키 r이 후보키 k의 일부를 가지고 있다면 cnt+1
+                if(r.contains(kIndex)) cnt++;
+            }
+            // 후보키 k 모두를 미래의 키 r이 가지고 있다면 true;
+            if(cnt==k.length()){
+                return true;
+            }
+        }
+        
+        return false;
+        
+    }
+ ```
+ 
+
+## 풀이
+```java
+import java.util.*;
+class Solution {
+
+    static boolean[] visited ;
+    static ArrayList<String> result ;
+    static ArrayList<String> key ;
+    
+    public int solution(String[][] relation) {
+        int answer = 0;
+        //후보키에 대한 고민
+        // 유일성 + 최소성: 꼭 필요한 속성들로만
+        // 이미 발견된 후보키가 다른 곳에 중복해서 들어갈 수 없음
+        // 모든 문자열은 알파벳 소문자와 숫자
+        // 모든 튜플은 유일하게 식별 가능 즉 중복되는 튜플은 없다.
+        
+        
+        //1. 모든 경우의 수 만들기
+        //2. 앞에서부터 시작해서 만약에 겹치는 후보키가 있다면 빼기
+        //3. 최종 개수 구하기
+        
+        //튜플의 수
+        int tuple = relation.length;
+        
+       
+        
+        // 경우의 수 조합을 위한 개수
+        int cnt  = relation[0].length;
+        visited = new boolean[cnt];
+        result  = new ArrayList<String>();
+        key = new ArrayList<String>();
+        
+        //dfs 로 경우의 수 하기
+        dfs(cnt,0,0,"");
+        
+        System.out.println("포함여부 124.contains(14)"+"124".contains("14"));
+        
+        
+        // 후보키 정렬하기
+        Comparator<String> comp = new Comparator<>(){
+            
+            public int compare(String s1, String s2){
+                return s1.length() -s2.length();
+            }  
+        };
+        
+        
+        // 짧은 배열부터 검사하기 위해서 정렬
+        Collections.sort(result,comp);
+        
+     
+       
+        
+        for(String r : result){
+            char[] charArr = r.toCharArray();
+            Set<String> set = new HashSet<>();
+            
+            for(int j=0;j<relation.length;j++){
+                StringBuilder sb = new StringBuilder();
+                for(char c : charArr){
+                    sb.append(relation[j][c-'0']).append(" ");
+                }
+                set.add(sb.toString());
+            }
+           
+            if(set.size()==tuple && !check(r,key)){
+                
+                   key.add(r);
+                   System.out.println("후보키:"+r);                
+                
+            }
+               
+        }
+        
+        return key.size();
+    }
+    
+    
+    static void dfs(int cnt, int start, int level, String answer) {
+        if(level==cnt){
+            return;
+        }else{
+            for(int i=start;i<cnt;i++){
+                  if(!visited[i]){
+                      visited[i]=true;
+                      dfs(cnt,i,level+1,answer+i);
+                      result.add(answer+i);
+                      visited[i]=false;   
+                  }     
+                   
+              }
+        }  
+    }
+    
+    static boolean check(String r ,ArrayList<String> key){
+        
+        
+        int cnt =0;
+        for(String k : key){
+            cnt =0;
+            String[] kArr = k.split("");
+            for(String kIndex : kArr){
+                if(r.contains(kIndex)) cnt++;
+            }
+            if(cnt==k.length()){
+                return true;
+            }
+        }
+        
+        return false;
+        
+    }
+    
+    
+}
+```


### PR DESCRIPTION
후보키 문제에서 발생한 ConcurrentModificationException

아무래도 i번째를 삭제할 때 i+1번째가 i번째로 당겨오게 되면서 그에 다른 검사가 누락되어 발생되는 것으로 보입니다.

사실 removeIf는 자바 8에 도입되었는데 Iterator의 불편함을 개선시키기 위해서 도입되었다고 했습니다. 즉 아래의 예시처럼 복잡한 코드를 한줄로 끝낼 수 있습니다.

```
Iterator<String> iter = li.iterator();
while(iter.hasNext()){
   if(iter.next().equalsIgnoreCase("str3"))
       iter.remove();
}
```
제가 저와 같은 상황으로 stack overflow에 올려진 글을 보았는데
이상하게도 removeIf나 Iterator를 이용하라고 했습니다.
하지만 여전히 ConcurrentModificationException이 발생되었습니다.

이 문제에 대해 혹시 아시는 분이 계시다면 의견 부탁드립니다~!